### PR TITLE
Fix snipe delay when not a wished character

### DIFF
--- a/MudaeAutoBot.py
+++ b/MudaeAutoBot.py
@@ -182,6 +182,9 @@ def get_snipe_time(channel,rolled,message):
         return 0.0
     
     wished_for = mention_finder.findall(message)
+    if not len(wished_for) and r == 3 or r == 4:
+        # Not a WISHED character, insta-snipe possible
+        return 0.0
     if r > 2 and user['id'] in wished_for:
         # Wisher can insta-snipe
         return 0.0


### PR DESCRIPTION
Issue #29 mentions this -- settings 3/4 only kick in if there's an *active* wish on the character