### PR TITLE
encoding utf-8 when opening the settings json file

### DIFF
--- a/MudaeAutoBot.py
+++ b/MudaeAutoBot.py
@@ -28,7 +28,7 @@ class CacheDict(OrderedDict):
 
 msg_buf = CacheDict(max=50)
 
-jsonf = open("Settings_Mudae.json")
+jsonf = open("Settings_Mudae.json", encoding="utf-8")
 settings = json.load(jsonf)
 jsonf.close()
 


### PR DESCRIPTION
the default cp1252 codec can't decode characters by bytes.... In my case, since I'm on Windows, I'll be given the Windows-1252 8bit character set. Setting encoding to utf-8 overrides this. this is for some list of character names in Mudae.
"""
Traceback (most recent call last):
  File "MudaeAutoBot.py", line 32, in <module>
    settings = json.load(jsonf)
  File "C:\ProgramData\Anaconda3\lib\json\__init__.py", line 293, in load
    return loads(fp.read(),
  File "C:\ProgramData\Anaconda3\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 5852: character maps to <undefined>
"""