### PR TITLE
fix parsing the wrong setting

### DIFF
--- a/MudaeAutoBot.py
+++ b/MudaeAutoBot.py
@@ -230,8 +230,8 @@ def parse_settings_message(message):
     settings['shift'] = int(num_parse(settings_p[4])[0])
     settings['max_rolls'] = int(num_parse(settings_p[5])[0])
     settings['expiry'] = float(num_parse(settings_p[6])[0])
-    settings['claim_snipe'] = [float(v) for v in num_parsedec(settings_p[15])]
-    settings['kak_snipe'] = [float(v) for v in num_parsedec(settings_p[16])]
+    settings['claim_snipe'] = [float(v) for v in num_parsedec(settings_p[16])]
+    settings['kak_snipe'] = [float(v) for v in num_parsedec(settings_p[17])]
     
 
     settings['claim_snipe'][0] = int(settings['claim_snipe'][0])


### PR DESCRIPTION

```jsonc
// settings_p value
[
    "**$** ($prefix)", // 0
    "**en** ($lang)", // 1
    "every **180** min. ($setclaim)", // 2
    "xx:**52** ($setinterval)", // 3
    "by +**0** min. ($shifthour)", // 4
    "**10** ($setrolls)", // 5
    "**30** sec. ($settimer)", // 6
    "**2** ($setrare)", // 7
    "**1** ($gamemode)", // 8
    "**1** ($channelinstance)", // 9
    "enabled ($toggleslash)", // 10
    "enabled ($toggleclaimrank/$togglelikerank)", // 11
    "claims only ($togglerolls)", // 12
    "enabled ($togglehentai)", // 13
    "enabled ($toggledisturbing)", // 14
    "enabled ($togglechildtag)", // 15
    "0 ($togglesnipe)", // 16
    "0 ($togglekakerasnipe)", // 17
    "**8100** ($haremlimit)",
    "****for all your rolls**** ($togglereact)",
    "no ($claimreact)",
    "no ($kakerareact switchset)",
    "enabled ($togglekakeratrade)",
    "claim and like ranks (and number of claimed characters) ($togglekakeraclaim/$togglekakeralike)",
    "enabled ($togglekakerarolls)",
    "enabled ($togglewishprotect)"
]
```

Fix #237. Pretty sure the error happens because of the new settings. (togglechildtag)
![2023-05-29-1685367320_grim](https://github.com/vivinano/MudaeAutoBot/assets/55097092/245e74d1-dcc9-4df3-ad98-5d1ad5a342aa)

In the new settings, for the `settings_p`, the `claim_snipe` and `kak_snipe` index become 16 and 17 respectively.