### PR TITLE
Fix claim_snipe/kak_snipe index due to $setkakerabonus being added

### DIFF
--- a/MudaeAutoBot.py
+++ b/MudaeAutoBot.py
@@ -230,8 +230,8 @@ def parse_settings_message(message):
     settings['shift'] = int(num_parse(settings_p[4])[0])
     settings['max_rolls'] = int(num_parse(settings_p[5])[0])
     settings['expiry'] = float(num_parse(settings_p[6])[0])
-    settings['claim_snipe'] = [float(v) for v in num_parsedec(settings_p[16])]
-    settings['kak_snipe'] = [float(v) for v in num_parsedec(settings_p[17])]
+    settings['claim_snipe'] = [float(v) for v in num_parsedec(settings_p[17])]
+    settings['kak_snipe'] = [float(v) for v in num_parsedec(settings_p[18])]
     
 
     settings['claim_snipe'][0] = int(settings['claim_snipe'][0])


### PR DESCRIPTION
The `$setkakerabonus` flag seems to be new. Can't find documentation on it anywhere.

Fixes the following error:

```
Traceback (most recent call last):
  File "~/projects/MudaeAutoBot/.devbox/virtenv/python310Packages.pip/.venv/lib/python3.10/site-packages/discum/gateway/gateway.py", line 299, in _response_loop
    func(resp)
  File "~/projects/MudaeAutoBot/MudaeAutoBot.py", line 811, in on_message
    c_settings = parse_settings_message(msg)
  File "~/projects/MudaeAutoBot/MudaeAutoBot.py", line 236, in parse_settings_message
    settings['claim_snipe'][0] = int(settings['claim_snipe'][0])
IndexError: list index out of range
```

This is my MudaeAutoBot auto-generated channeldata:

```
_ __**Server Settings**__ _
(Server not premium)

· Prefix: **$** ($prefix)
· Lang: **en** ($lang)
· Claim reset: every **180** min. ($setclaim)
· Exact minute of the reset: xx:**12** ($setinterval)
· Reset shifted: by +**0** min. ($shifthour)
· Rolls per hour: **8** ($setrolls)
· Time before the claim reaction expires: **45** sec. ($settimer)
· Spawn rarity multiplicator for already claimed characters: **1** ($setrare)
· % kakera bonus: **+0** ($setkakerabonus)
· Server game mode: **2** ($gamemode)
· $servlimroul = 7000 $wa, 7000 $ha, 4000 $wg, 4000 $hg
· This channel instance: **1** ($channelinstance)
· Slash commands: enabled ($toggleslash)

· Ranking: enabled ($toggleclaimrank/$togglelikerank)
· Ranks displayed during rolls: **disabled** ($togglerolls)
· Hentai series: enabled ($togglehentai)
· Disturbing imagery series: enabled ($toggledisturbing)
· Child characters: enabled ($togglechildtag)
· Rolls sniping: 0 ($togglesnipe)
· Kakera sniping: 0 ($togglekakerasnipe)
· Limit of characters per harem: **8100** ($haremlimit)
· Reacts: ****for public wishes only**** ($togglereact)
· Custom reactions: no ($claimreact)
· Kakera reactions more recognizable: no ($kakerareact switchset)

· Kakera trading: enabled ($togglekakeratrade)
· Kakera calculation: claim and like ranks (and number of claimed characters) ($togglekakeraclaim/$togglekakeralike)
· Kakera value displayed during rolls: enabled ($togglekakerarolls)
· $kakeraloot wishprotect: enabled ($togglewishprotect)
```

Debugged values:
```
settings_p = [
    "**$** ($prefix)", #0
    "**en** ($lang)", #1
    "every **180** min. ($setclaim)", #2
    "xx:**12** ($setinterval)", #3
    "by +**0** min. ($shifthour)", #4
    "**8** ($setrolls)", #5
    "**45** sec. ($settimer)", #6
    "**1** ($setrare)", #7
    "**+0** ($setkakerabonus)", #8
    "**2** ($gamemode)", #9
    "**1** ($channelinstance)", #10
    "enabled ($toggleslash)", #11
    "enabled ($toggleclaimrank/$togglelikerank)", #12
    "**disabled** ($togglerolls)", #13
    "enabled ($togglehentai)", #14
    "enabled ($toggledisturbing)", #15
    "enabled ($togglechildtag)", #16
    "0 ($togglesnipe)", #17
    "0 ($togglekakerasnipe)", #18
    "**8100** ($haremlimit)", #19
    "****for public wishes only**** ($togglereact)", #20
    "no ($claimreact)", #21
    "no ($kakerareact switchset)", #22
    "enabled ($togglekakeratrade)", #23
    "claim and like ranks (and number of claimed characters) ($togglekakeraclaim/$togglekakeralike)", #24
    "enabled ($togglekakerarolls)", #25
    "enabled ($togglewishprotect)", #26
]
```